### PR TITLE
Fix problem where exception thrown from getStackEvents gets ignored

### DIFF
--- a/src/main/java/jp/classmethod/aws/reboot/gradle/cloudformation/StatusWaiter.java
+++ b/src/main/java/jp/classmethod/aws/reboot/gradle/cloudformation/StatusWaiter.java
@@ -86,12 +86,12 @@ public abstract class StatusWaiter {
 			}
 			try {
 				lastStatus = getStatus();
-				
-				found = true;
-				
+
 				// Get stack events info
 				List<StackEvent> stackEvents = getStackEvents(stackName);
-				
+
+				found = true;
+
 				// Always output new events; might be the last time you can
 				printEvents(stackEvents, printedEvents);
 				


### PR DESCRIPTION
This problem could happen, for example, if the IAM role used to run the Gradle task doesn't have the `cloudformation:DescribeStackEvents` permission.

If `found == true` exceptions are ignored. This code change defers the setting of this magic flag until after the describe stacks call has been made.

This means if describe stacks fails, it will now correctly throw an exception.

I can't be certain that this change won't have unintended side-effects. If it does, I suggest we fix them as they occur, using more fine-grained and robust exception handling logic.